### PR TITLE
Run generate to populate pack2 code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.13.8 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-os-gardenlinux
 COPY . .
-RUN make install
+RUN make install-requirements && make generate && make install
 
 ############# gardener-extension-os-gardenlinux
 FROM alpine:3.11.3 AS gardener-extension-os-gardenlinux


### PR DESCRIPTION
**What this PR does / why we need it**:
The controller currently is failing with:
```
$ k -n extension-os-gardenlinux-4gtjw get po
NAME                                                 READY   STATUS             RESTARTS   AGE
gardener-extension-os-gardenlinux-7f6987f9bd-225lc   0/1     CrashLoopBackOff   1          11s
$ k -n extension-os-gardenlinux-4gtjw logs gardener-extension-os-gardenlinux-7f6987f9bd-225lc -f
panic: stat /templates/cloud-init.gardenlinux.template: no such file or directory

goroutine 1 [running]:
k8s.io/apimachinery/pkg/util/runtime.Must(...)
	/go/src/github.com/gardener/gardener-extension-os-gardenlinux/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:171
github.com/gardener/gardener-extension-os-gardenlinux/pkg/generator.init.0()
	/go/src/github.com/gardener/gardener-extension-os-gardenlinux/pkg/generator/generator.go:33 +0x35f
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
