### PR TITLE
preload nfsd module

### DIFF
--- a/pkg/generator/templates/cloud-init.gardenlinux.template
+++ b/pkg/generator/templates/cloud-init.gardenlinux.template
@@ -26,6 +26,8 @@ mkdir -p '{{ $unit.DropIns.Path }}'
 {{- end }}
 {{- end }}
 
+grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
+modprobe nfsd
 systemctl daemon-reload
 {{ if .Bootstrap }}
 systemctl enable docker && systemctl restart docker

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -15,6 +15,8 @@ cat << EOF | base64 -d > '/etc/systemd/system/docker.service.d/10-docker-opts.co
 b3ZlcnJpZGU=
 EOF
 
+grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
+modprobe nfsd
 systemctl daemon-reload
 
 systemctl enable docker && systemctl restart docker


### PR DESCRIPTION
**What this PR does / why we need it**:
Preload `nfsd` module
**Which issue(s) this PR fixes**:
Mitigate https://github.com/docker/for-linux/issues/996

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
`nfsd` module is now preloaded for both existing and newly created VMs with Garden Linux.
```
