### PR TITLE
mitigate failing to resolve cluster's VM hostname

### DIFF
--- a/pkg/generator/templates/cloud-init.gardenlinux.template
+++ b/pkg/generator/templates/cloud-init.gardenlinux.template
@@ -38,6 +38,7 @@ mkdir -p '{{ $unit.DropIns.Path }}'
 
 grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
+nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 {{- if .Bootstrap }}
 {{- if isContainerDEnabled .CRI }}

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -19,6 +19,7 @@ EOF
 
 grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
+nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 systemctl enable docker && systemctl restart docker
 systemctl enable 'docker.service' && systemctl restart 'docker.service'

--- a/pkg/generator/testfiles/containerd-bootstrap
+++ b/pkg/generator/testfiles/containerd-bootstrap
@@ -29,6 +29,7 @@ EOF
 
 grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
+nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 systemctl enable containerd && systemctl restart containerd
 systemctl enable docker && systemctl restart docker

--- a/pkg/generator/testfiles/containerd-reconcile
+++ b/pkg/generator/testfiles/containerd-reconcile
@@ -22,6 +22,7 @@ EOF
 
 grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
+nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 systemctl enable 'unit1' && systemctl restart 'unit1'
 systemctl enable 'unit2' && systemctl restart 'unit2'

--- a/pkg/generator/testfiles/docker-bootstrap
+++ b/pkg/generator/testfiles/docker-bootstrap
@@ -22,6 +22,7 @@ EOF
 
 grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
+nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 systemctl enable docker && systemctl restart docker
 systemctl enable 'unit1' && systemctl restart 'unit1'

--- a/pkg/generator/testfiles/docker-reconcile
+++ b/pkg/generator/testfiles/docker-reconcile
@@ -22,6 +22,7 @@ EOF
 
 grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
+nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 systemctl enable 'unit1' && systemctl restart 'unit1'
 systemctl enable 'unit2' && systemctl restart 'unit2'


### PR DESCRIPTION
**What this PR does / why we need it**:
Temporary mitigation of https://github.com/gardenlinux/gardenlinux/issues/107 till it is permanently fixed in the Garden Linux.

**Which issue(s) this PR fixes**:
Mitigates https://github.com/gardenlinux/gardenlinux/issues/107
 
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Mitigate an issue observed on Azure shoot clusters where Garden Linux VMs do not register their hostnames with the DHCP server. 
```
