### PR TITLE
Do not start docker when bootstrapping CRI nodes

### DIFF
--- a/pkg/generator/templates/cloud-init.gardenlinux.template
+++ b/pkg/generator/templates/cloud-init.gardenlinux.template
@@ -43,8 +43,9 @@ systemctl daemon-reload
 {{- if .Bootstrap }}
 {{- if isContainerDEnabled .CRI }}
 systemctl enable containerd && systemctl restart containerd
+{{- else }}
+systemctl enable docker.service && systemctl enable docker.socket && systemctl restart docker
 {{- end }}
-systemctl enable docker && systemctl restart docker
 {{- end }}
 
 {{- range $_, $unit := .Units }}

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -21,5 +21,5 @@ grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
-systemctl enable docker && systemctl restart docker
+systemctl enable docker.service && systemctl enable docker.socket && systemctl restart docker
 systemctl enable 'docker.service' && systemctl restart 'docker.service'

--- a/pkg/generator/testfiles/containerd-bootstrap
+++ b/pkg/generator/testfiles/containerd-bootstrap
@@ -32,6 +32,5 @@ modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 systemctl enable containerd && systemctl restart containerd
-systemctl enable docker && systemctl restart docker
 systemctl enable 'unit1' && systemctl restart 'unit1'
 systemctl enable 'unit2' && systemctl restart 'unit2'

--- a/pkg/generator/testfiles/docker-bootstrap
+++ b/pkg/generator/testfiles/docker-bootstrap
@@ -24,6 +24,6 @@ grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
-systemctl enable docker && systemctl restart docker
+systemctl enable docker.service && systemctl enable docker.socket && systemctl restart docker
 systemctl enable 'unit1' && systemctl restart 'unit1'
 systemctl enable 'unit2' && systemctl restart 'unit2'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/priority normal
/os gardenlinux

**What this PR does / why we need it**:

With [refactorings to the Gardener node bootstrap process for CRI enabled worker groups](https://github.com/gardener/gardener/pull/2739), docker is not strictly required any more for bootstrapping. 
Therefore this PR, when CRI `containerd` is used, only makes sure that `containerd` is installed, enabled & started.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- Waiting for [this PR](https://github.com/gardener/gardener/pull/2739) in the Gardener to be reviewed and merged.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
