### PR TITLE
[gl-27] Increase docker memorylock limit and install cifs-utils

### DIFF
--- a/pkg/generator/templates/cloud-init.gardenlinux.template
+++ b/pkg/generator/templates/cloud-init.gardenlinux.template
@@ -44,6 +44,26 @@ systemctl daemon-reload
 {{- if isContainerDEnabled .CRI }}
 systemctl enable containerd && systemctl restart containerd
 {{- end }}
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release
+then
+    PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
+    mount -o remount,rw ${PARTITION} /usr
+    until apt update -qq && apt install --no-upgrade -qqy cifs-utils; do sleep 1; done
+    mount -o remount,ro ${PARTITION} /usr
+
+    mkdir -p /etc/docker
+    cat << EOF > /etc/docker/daemon.json
+{ "storage-driver": "overlay2",
+  "default-ulimits": {
+      "memlock": {
+          "name": "memlock",
+          "hard": 67108864,
+          "soft": 67108864
+      }
+  }
+}
+EOF
+fi
 systemctl enable docker && systemctl restart docker
 {{- end }}
 

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -21,5 +21,25 @@ grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release
+then
+    PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
+    mount -o remount,rw ${PARTITION} /usr
+    until apt update -qq && apt install --no-upgrade -qqy cifs-utils; do sleep 1; done
+    mount -o remount,ro ${PARTITION} /usr
+
+    mkdir -p /etc/docker
+    cat << EOF > /etc/docker/daemon.json
+{ "storage-driver": "overlay2",
+  "default-ulimits": {
+      "memlock": {
+          "name": "memlock",
+          "hard": 67108864,
+          "soft": 67108864
+      }
+  }
+}
+EOF
+fi
 systemctl enable docker && systemctl restart docker
 systemctl enable 'docker.service' && systemctl restart 'docker.service'

--- a/pkg/generator/testfiles/containerd-bootstrap
+++ b/pkg/generator/testfiles/containerd-bootstrap
@@ -32,6 +32,26 @@ modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 systemctl enable containerd && systemctl restart containerd
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release
+then
+    PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
+    mount -o remount,rw ${PARTITION} /usr
+    until apt update -qq && apt install --no-upgrade -qqy cifs-utils; do sleep 1; done
+    mount -o remount,ro ${PARTITION} /usr
+
+    mkdir -p /etc/docker
+    cat << EOF > /etc/docker/daemon.json
+{ "storage-driver": "overlay2",
+  "default-ulimits": {
+      "memlock": {
+          "name": "memlock",
+          "hard": 67108864,
+          "soft": 67108864
+      }
+  }
+}
+EOF
+fi
 systemctl enable docker && systemctl restart docker
 systemctl enable 'unit1' && systemctl restart 'unit1'
 systemctl enable 'unit2' && systemctl restart 'unit2'

--- a/pkg/generator/testfiles/docker-bootstrap
+++ b/pkg/generator/testfiles/docker-bootstrap
@@ -24,6 +24,26 @@ grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release
+then
+    PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
+    mount -o remount,rw ${PARTITION} /usr
+    until apt update -qq && apt install --no-upgrade -qqy cifs-utils; do sleep 1; done
+    mount -o remount,ro ${PARTITION} /usr
+
+    mkdir -p /etc/docker
+    cat << EOF > /etc/docker/daemon.json
+{ "storage-driver": "overlay2",
+  "default-ulimits": {
+      "memlock": {
+          "name": "memlock",
+          "hard": 67108864,
+          "soft": 67108864
+      }
+  }
+}
+EOF
+fi
 systemctl enable docker && systemctl restart docker
 systemctl enable 'unit1' && systemctl restart 'unit1'
 systemctl enable 'unit2' && systemctl restart 'unit2'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/priority normal
/os garden-linux

**What this PR does / why we need it**:
A mitigation for Garden linux 27.1 and 27.0 that do:
- install cifs-utils from the package registry (done in the upstream https://github.com/gardenlinux/gardenlinux/pull/103)
- increase the memlock limit for docker containers to mitigate https://github.com/golang/go/wiki/LinuxKernelSignalVectorBug (done in the upstream https://github.com/gardenlinux/gardenlinux/pull/128)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ccwienk @hoeltcl @gehoern 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Docker memory lock limit is increased to 64MB (needed to mitigate https://github.com/golang/go/wiki/LinuxKernelSignalVectorBug) and cifs-utils package is installed (required to enable cifs volumes) on Garden Linux 27.0 and 27.1 nodes. To get this change applied, the shoot owners must trigger rollout of their worker pools.
```
