### PR TITLE
[gl-27] Install cifs-utils on existing nodes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -21,7 +21,7 @@ If multiple identifiers make sense you can also state the commands multiple time
 /area TODO
 /kind bug
 /priority normal
-/os gardenlinux
+/os garden-linux
 
 **What happened**:
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -21,7 +21,7 @@ If multiple identifiers make sense you can also state the commands multiple time
 /area TODO
 /kind enhancement
 /priority normal
-/os gardenlinux
+/os garden-linux
 
 **What would you like to be added**:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@ For Gardener Enhancement Proposals (GEPs), please check the following [documenta
 /area TODO
 /kind TODO
 /priority normal
-/os gardenlinux
+/os garden-linux
 
 **What this PR does / why we need it**:
 

--- a/hack/update-github-templates.sh
+++ b/hack/update-github-templates.sh
@@ -26,6 +26,6 @@ for file in `find "$(dirname $0)"/../vendor/github.com/gardener/gardener/.github
     sed 's/to the Gardener project/for this extension/g' |\
     sed 's/to Gardener/to this extension/g' |\
     sed 's/- Gardener version:/- Gardener version (if relevant):\n- Extension version:/g' |\
-    sed 's/\/priority normal/\/priority normal\n\/os gardenlinux/g' \
+    sed 's/\/priority normal/\/priority normal\n\/os garden-linux/g' \
   > "$(dirname $0)/../.github/${file#*.github/}"
 done

--- a/pkg/generator/templates/cloud-init.gardenlinux.template
+++ b/pkg/generator/templates/cloud-init.gardenlinux.template
@@ -40,17 +40,24 @@ grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
+
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg-query --show cifs-utils &>/dev/null
+then
+    PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
+    mount -o remount,rw ${PARTITION} /usr
+    until apt update -qq && apt install --no-upgrade -qqy cifs-utils
+    do
+        sleep 1
+    done
+    mount -o remount,ro ${PARTITION} /usr
+fi
+
 {{- if .Bootstrap }}
 {{- if isContainerDEnabled .CRI }}
 systemctl enable containerd && systemctl restart containerd
 {{- end }}
 if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release
 then
-    PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
-    mount -o remount,rw ${PARTITION} /usr
-    until apt update -qq && apt install --no-upgrade -qqy cifs-utils; do sleep 1; done
-    mount -o remount,ro ${PARTITION} /usr
-
     mkdir -p /etc/docker
     cat << EOF > /etc/docker/daemon.json
 { "storage-driver": "overlay2",

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -21,13 +21,19 @@ grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release
+
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg-query --show cifs-utils &>/dev/null
 then
     PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
     mount -o remount,rw ${PARTITION} /usr
-    until apt update -qq && apt install --no-upgrade -qqy cifs-utils; do sleep 1; done
+    until apt update -qq && apt install --no-upgrade -qqy cifs-utils
+    do
+        sleep 1
+    done
     mount -o remount,ro ${PARTITION} /usr
-
+fi
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release
+then
     mkdir -p /etc/docker
     cat << EOF > /etc/docker/daemon.json
 { "storage-driver": "overlay2",

--- a/pkg/generator/testfiles/containerd-bootstrap
+++ b/pkg/generator/testfiles/containerd-bootstrap
@@ -31,14 +31,20 @@ grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
-systemctl enable containerd && systemctl restart containerd
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release
+
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg-query --show cifs-utils &>/dev/null
 then
     PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
     mount -o remount,rw ${PARTITION} /usr
-    until apt update -qq && apt install --no-upgrade -qqy cifs-utils; do sleep 1; done
+    until apt update -qq && apt install --no-upgrade -qqy cifs-utils
+    do
+        sleep 1
+    done
     mount -o remount,ro ${PARTITION} /usr
-
+fi
+systemctl enable containerd && systemctl restart containerd
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release
+then
     mkdir -p /etc/docker
     cat << EOF > /etc/docker/daemon.json
 { "storage-driver": "overlay2",

--- a/pkg/generator/testfiles/containerd-reconcile
+++ b/pkg/generator/testfiles/containerd-reconcile
@@ -24,5 +24,16 @@ grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
+
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg-query --show cifs-utils &>/dev/null
+then
+    PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
+    mount -o remount,rw ${PARTITION} /usr
+    until apt update -qq && apt install --no-upgrade -qqy cifs-utils
+    do
+        sleep 1
+    done
+    mount -o remount,ro ${PARTITION} /usr
+fi
 systemctl enable 'unit1' && systemctl restart 'unit1'
 systemctl enable 'unit2' && systemctl restart 'unit2'

--- a/pkg/generator/testfiles/docker-bootstrap
+++ b/pkg/generator/testfiles/docker-bootstrap
@@ -24,13 +24,19 @@ grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release
+
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg-query --show cifs-utils &>/dev/null
 then
     PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
     mount -o remount,rw ${PARTITION} /usr
-    until apt update -qq && apt install --no-upgrade -qqy cifs-utils; do sleep 1; done
+    until apt update -qq && apt install --no-upgrade -qqy cifs-utils
+    do
+        sleep 1
+    done
     mount -o remount,ro ${PARTITION} /usr
-
+fi
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release
+then
     mkdir -p /etc/docker
     cat << EOF > /etc/docker/daemon.json
 { "storage-driver": "overlay2",

--- a/pkg/generator/testfiles/docker-reconcile
+++ b/pkg/generator/testfiles/docker-reconcile
@@ -24,5 +24,16 @@ grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
+
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg-query --show cifs-utils &>/dev/null
+then
+    PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
+    mount -o remount,rw ${PARTITION} /usr
+    until apt update -qq && apt install --no-upgrade -qqy cifs-utils
+    do
+        sleep 1
+    done
+    mount -o remount,ro ${PARTITION} /usr
+fi
 systemctl enable 'unit1' && systemctl restart 'unit1'
 systemctl enable 'unit2' && systemctl restart 'unit2'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/priority normal
/os garden-linux

**What this PR does / why we need it**:
cifs-utils package will be installed even on existing Garden Linux 27.[0|1] nodes.

**Which issue(s) this PR fixes**:
Follow up on #14

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
[Previously](https://github.com/gardener/gardener-extension-os-gardenlinux/pull/14/), `cifs-utils` was installed only on newly created Garden Linux nodes, now it is installed also on already existing nodes that are missing this package.
```
