### PR TITLE
[gl-27] Install xfsprogs

### DIFF
--- a/pkg/generator/templates/cloud-init.gardenlinux.template
+++ b/pkg/generator/templates/cloud-init.gardenlinux.template
@@ -41,11 +41,11 @@ modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg-query --show cifs-utils &>/dev/null
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg -V cifs-utils xfsprogs &>/dev/null
 then
     PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
     mount -o remount,rw ${PARTITION} /usr
-    until apt update -qq && apt install --no-upgrade -qqy cifs-utils
+    until apt update -qq && apt install --no-upgrade -qqy cifs-utils xfsprogs
     do
         sleep 1
     done

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -22,11 +22,11 @@ modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg-query --show cifs-utils &>/dev/null
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg -V cifs-utils xfsprogs &>/dev/null
 then
     PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
     mount -o remount,rw ${PARTITION} /usr
-    until apt update -qq && apt install --no-upgrade -qqy cifs-utils
+    until apt update -qq && apt install --no-upgrade -qqy cifs-utils xfsprogs
     do
         sleep 1
     done

--- a/pkg/generator/testfiles/containerd-bootstrap
+++ b/pkg/generator/testfiles/containerd-bootstrap
@@ -32,11 +32,11 @@ modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg-query --show cifs-utils &>/dev/null
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg -V cifs-utils xfsprogs &>/dev/null
 then
     PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
     mount -o remount,rw ${PARTITION} /usr
-    until apt update -qq && apt install --no-upgrade -qqy cifs-utils
+    until apt update -qq && apt install --no-upgrade -qqy cifs-utils xfsprogs
     do
         sleep 1
     done

--- a/pkg/generator/testfiles/containerd-reconcile
+++ b/pkg/generator/testfiles/containerd-reconcile
@@ -25,11 +25,11 @@ modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg-query --show cifs-utils &>/dev/null
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg -V cifs-utils xfsprogs &>/dev/null
 then
     PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
     mount -o remount,rw ${PARTITION} /usr
-    until apt update -qq && apt install --no-upgrade -qqy cifs-utils
+    until apt update -qq && apt install --no-upgrade -qqy cifs-utils xfsprogs
     do
         sleep 1
     done

--- a/pkg/generator/testfiles/docker-bootstrap
+++ b/pkg/generator/testfiles/docker-bootstrap
@@ -25,11 +25,11 @@ modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg-query --show cifs-utils &>/dev/null
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg -V cifs-utils xfsprogs &>/dev/null
 then
     PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
     mount -o remount,rw ${PARTITION} /usr
-    until apt update -qq && apt install --no-upgrade -qqy cifs-utils
+    until apt update -qq && apt install --no-upgrade -qqy cifs-utils xfsprogs
     do
         sleep 1
     done

--- a/pkg/generator/testfiles/docker-reconcile
+++ b/pkg/generator/testfiles/docker-reconcile
@@ -25,11 +25,11 @@ modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg-query --show cifs-utils &>/dev/null
+if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg -V cifs-utils xfsprogs &>/dev/null
 then
     PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
     mount -o remount,rw ${PARTITION} /usr
-    until apt update -qq && apt install --no-upgrade -qqy cifs-utils
+    until apt update -qq && apt install --no-upgrade -qqy cifs-utils xfsprogs
     do
         sleep 1
     done


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/priority normal
/os garden-linux
/assign @mvladev 
/invite @mvladev 

**What this PR does / why we need it**:
Install xfsprogs package on GL 27.0 and 27.1 nodes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The upstream change is here https://github.com/gardenlinux/gardenlinux/commit/17f223a7826b41a727656798df59b57f4e7300b1

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
`xfsprogs` package is installed (required to enable xfs volumes) on Garden Linux 27.0 and 27.1 nodes.
```