### PR TITLE
Remove support for Garden Linux 27.0 and 27.1

### DIFF
--- a/pkg/generator/templates/cloud-init.gardenlinux.template
+++ b/pkg/generator/templates/cloud-init.gardenlinux.template
@@ -41,36 +41,10 @@ modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg -V cifs-utils xfsprogs &>/dev/null
-then
-    PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
-    mount -o remount,rw ${PARTITION} /usr
-    until apt update -qq && apt install --no-upgrade -qqy cifs-utils xfsprogs
-    do
-        sleep 1
-    done
-    mount -o remount,ro ${PARTITION} /usr
-fi
-
 {{- if .Bootstrap }}
 {{- if isContainerDEnabled .CRI }}
 systemctl enable containerd && systemctl restart containerd
 {{- end }}
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release
-then
-    mkdir -p /etc/docker
-    cat << EOF > /etc/docker/daemon.json
-{ "storage-driver": "overlay2",
-  "default-ulimits": {
-      "memlock": {
-          "name": "memlock",
-          "hard": 67108864,
-          "soft": 67108864
-      }
-  }
-}
-EOF
-fi
 systemctl enable docker && systemctl restart docker
 {{- end }}
 

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -21,31 +21,5 @@ grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
-
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg -V cifs-utils xfsprogs &>/dev/null
-then
-    PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
-    mount -o remount,rw ${PARTITION} /usr
-    until apt update -qq && apt install --no-upgrade -qqy cifs-utils xfsprogs
-    do
-        sleep 1
-    done
-    mount -o remount,ro ${PARTITION} /usr
-fi
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release
-then
-    mkdir -p /etc/docker
-    cat << EOF > /etc/docker/daemon.json
-{ "storage-driver": "overlay2",
-  "default-ulimits": {
-      "memlock": {
-          "name": "memlock",
-          "hard": 67108864,
-          "soft": 67108864
-      }
-  }
-}
-EOF
-fi
 systemctl enable docker && systemctl restart docker
 systemctl enable 'docker.service' && systemctl restart 'docker.service'

--- a/pkg/generator/testfiles/containerd-bootstrap
+++ b/pkg/generator/testfiles/containerd-bootstrap
@@ -32,33 +32,7 @@ grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
-
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg -V cifs-utils xfsprogs &>/dev/null
-then
-    PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
-    mount -o remount,rw ${PARTITION} /usr
-    until apt update -qq && apt install --no-upgrade -qqy cifs-utils xfsprogs
-    do
-        sleep 1
-    done
-    mount -o remount,ro ${PARTITION} /usr
-fi
 systemctl enable containerd && systemctl restart containerd
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release
-then
-    mkdir -p /etc/docker
-    cat << EOF > /etc/docker/daemon.json
-{ "storage-driver": "overlay2",
-  "default-ulimits": {
-      "memlock": {
-          "name": "memlock",
-          "hard": 67108864,
-          "soft": 67108864
-      }
-  }
-}
-EOF
-fi
 systemctl enable docker && systemctl restart docker
 systemctl enable 'unit1' && systemctl restart 'unit1'
 systemctl enable 'unit2' && systemctl restart 'unit2'

--- a/pkg/generator/testfiles/containerd-reconcile
+++ b/pkg/generator/testfiles/containerd-reconcile
@@ -25,16 +25,5 @@ grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
-
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg -V cifs-utils xfsprogs &>/dev/null
-then
-    PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
-    mount -o remount,rw ${PARTITION} /usr
-    until apt update -qq && apt install --no-upgrade -qqy cifs-utils xfsprogs
-    do
-        sleep 1
-    done
-    mount -o remount,ro ${PARTITION} /usr
-fi
 systemctl enable 'unit1' && systemctl restart 'unit1'
 systemctl enable 'unit2' && systemctl restart 'unit2'

--- a/pkg/generator/testfiles/docker-bootstrap
+++ b/pkg/generator/testfiles/docker-bootstrap
@@ -25,32 +25,6 @@ grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
-
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg -V cifs-utils xfsprogs &>/dev/null
-then
-    PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
-    mount -o remount,rw ${PARTITION} /usr
-    until apt update -qq && apt install --no-upgrade -qqy cifs-utils xfsprogs
-    do
-        sleep 1
-    done
-    mount -o remount,ro ${PARTITION} /usr
-fi
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release
-then
-    mkdir -p /etc/docker
-    cat << EOF > /etc/docker/daemon.json
-{ "storage-driver": "overlay2",
-  "default-ulimits": {
-      "memlock": {
-          "name": "memlock",
-          "hard": 67108864,
-          "soft": 67108864
-      }
-  }
-}
-EOF
-fi
 systemctl enable docker && systemctl restart docker
 systemctl enable 'unit1' && systemctl restart 'unit1'
 systemctl enable 'unit2' && systemctl restart 'unit2'

--- a/pkg/generator/testfiles/docker-reconcile
+++ b/pkg/generator/testfiles/docker-reconcile
@@ -25,16 +25,5 @@ grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
-
-if grep -q '^GARDENLINUX_BUILD_ID=27.[01]' /etc/os-release && ! dpkg -V cifs-utils xfsprogs &>/dev/null
-then
-    PARTITION=$(mount -v | grep "^/.*/usr" | awk '{print $1}')
-    mount -o remount,rw ${PARTITION} /usr
-    until apt update -qq && apt install --no-upgrade -qqy cifs-utils xfsprogs
-    do
-        sleep 1
-    done
-    mount -o remount,ro ${PARTITION} /usr
-fi
 systemctl enable 'unit1' && systemctl restart 'unit1'
 systemctl enable 'unit2' && systemctl restart 'unit2'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind cleanup
/priority normal
/os garden-linux

**What this PR does / why we need it**:
Remove support for Garden Linux 27.0 and 27.1

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
:warning: Support for Garden Linux versions 27.0 and 27.1 has been removed from this extension. Please, ensure that all shoot clusters in your landscape are running on Garden Linux 184.0 or newer version before upgrading to this version of the extension.
```
