### PR TITLE
Use dedicated secret for the sample OSC

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ spec:
     ...
 ```
 
-Please find [a concrete example](example/operatingsystemconfig.yaml) in the `example` folder.
+Please find [a concrete example](example/40-operatingsystemconfig.yaml) in the `example` folder.
 
 After reconciliation the resulting data will be stored in a secret within the same namespace (as the config itself might contain confidential data). The name of the secret will be written into the resource's `.status` field:
 

--- a/example/30-secret.yaml
+++ b/example/30-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example-file
+  namespace: default
+type: Opaque
+data:
+  file.txt: VGhpcyBpcyBhIHNhbXBsZSBmaWxlLgo=

--- a/example/40-operatingsystemconfig.yaml
+++ b/example/40-operatingsystemconfig.yaml
@@ -27,13 +27,13 @@ spec:
       EnvironmentFile=/etc/environment
       ExecStart=/opt/bin/health-monitor docker
   files:
-  - path: /var/lib/kubelet/ca.crt
+  - path: /var/lib/example/file.txt
     permissions: 0644
     encoding: b64
     content:
       secretRef:
-        name: default-token-d9nzl
-        dataKey: token
+        name: example-file
+        dataKey: file.txt
   - path: /etc/sysctl.d/99-k8s-general.conf
     permissions: 0644
     content:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement
/os garden-linux

**What this PR does / why we need it**:
The default token secret has different name in each k8s cluster.
Therefore it is always required to update the examples in order to use them.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
