### PR TITLE
Avoid unnecessary restart of services

### DIFF
--- a/pkg/generator/templates/cloud-init.gardenlinux.template
+++ b/pkg/generator/templates/cloud-init.gardenlinux.template
@@ -49,17 +49,12 @@ mkdir -p '{{ $unit.DropIns.Path }}'
 grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
-systemctl daemon-reload
 
 {{- if .Bootstrap }}
+systemctl daemon-reload
 {{- if isContainerDEnabled .CRI }}
 systemctl enable containerd && systemctl restart containerd
 {{- end }}
 systemctl enable docker && systemctl restart docker
-{{- end }}
-
-{{- range $_, $unit := .Units }}
-{{- if or (ne $unit.Name "cloud-config-downloader.service") ($.Bootstrap) }}
-systemctl enable '{{ $unit.Name }}' && systemctl restart '{{ $unit.Name }}'
-{{- end }}
+systemctl enable cloud-config-downloader && systemctl restart cloud-config-downloader
 {{- end }}

--- a/pkg/generator/testfiles/cloud-init
+++ b/pkg/generator/testfiles/cloud-init
@@ -27,4 +27,4 @@ modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 systemctl enable docker && systemctl restart docker
-systemctl enable 'docker.service' && systemctl restart 'docker.service'
+systemctl enable cloud-config-downloader && systemctl restart cloud-config-downloader

--- a/pkg/generator/testfiles/containerd-bootstrap
+++ b/pkg/generator/testfiles/containerd-bootstrap
@@ -34,6 +34,4 @@ nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 systemctl enable containerd && systemctl restart containerd
 systemctl enable docker && systemctl restart docker
-systemctl enable 'unit1' && systemctl restart 'unit1'
-systemctl enable 'unit2' && systemctl restart 'unit2'
-systemctl enable 'cloud-config-downloader.service' && systemctl restart 'cloud-config-downloader.service'
+systemctl enable cloud-config-downloader && systemctl restart cloud-config-downloader

--- a/pkg/generator/testfiles/containerd-reconcile
+++ b/pkg/generator/testfiles/containerd-reconcile
@@ -24,6 +24,3 @@ EOF
 grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
-systemctl daemon-reload
-systemctl enable 'unit1' && systemctl restart 'unit1'
-systemctl enable 'unit2' && systemctl restart 'unit2'

--- a/pkg/generator/testfiles/docker-bootstrap
+++ b/pkg/generator/testfiles/docker-bootstrap
@@ -26,6 +26,4 @@ modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
 systemctl daemon-reload
 systemctl enable docker && systemctl restart docker
-systemctl enable 'unit1' && systemctl restart 'unit1'
-systemctl enable 'unit2' && systemctl restart 'unit2'
-systemctl enable 'cloud-config-downloader.service' && systemctl restart 'cloud-config-downloader.service'
+systemctl enable cloud-config-downloader && systemctl restart cloud-config-downloader

--- a/pkg/generator/testfiles/docker-reconcile
+++ b/pkg/generator/testfiles/docker-reconcile
@@ -24,6 +24,3 @@ EOF
 grep -sq "^nfsd$" /etc/modules || echo "nfsd" >>/etc/modules
 modprobe nfsd
 nslookup $(hostname) || systemctl restart systemd-networkd
-systemctl daemon-reload
-systemctl enable 'unit1' && systemctl restart 'unit1'
-systemctl enable 'unit2' && systemctl restart 'unit2'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind TODO
/os garden-linux

**What this PR does / why we need it**:
Avoid unnecessary restart of systemd services.
The service restarts are executed by the script maintained in Gardener here https://github.com/gardener/gardener/blob/master/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh#L133.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I have started a cluster with this change, the nodes joined the cluster, however the VPN was flaky and the creation could'nt finish successfully. Will proceed tomorrow.

cc @rfranzke @marwinski 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
This extension is now longer restarting the systemd services from the original OperatingSystemConfig units.
```
