### PR TITLE
Fix `oscommon` link to g/g repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The secret has one data key `cloud_config` that stores the generation.
 
 An example for a `ControllerRegistration` resource that can be used to register this controller to Gardener can be found [here](example/controller-registration.yaml).
 
-This controller is based on revision [b5ba8164](https://github.com/gardener/gardener-extension-os-ubuntu-alicloud/commit/b5ba8164ed4c52872b1d4bd5ee3eaa4ed58da966) of [gardener-extension-os-ubuntu-alicloud](https://github.com/gardener/gardener-extension-os-ubuntu-alicloud). Its implementation is using the [`oscommon`](https://github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/README.md) library for operating system configuration controllers.
+This controller is based on revision [b5ba8164](https://github.com/gardener/gardener-extension-os-ubuntu-alicloud/commit/b5ba8164ed4c52872b1d4bd5ee3eaa4ed58da966) of [gardener-extension-os-ubuntu-alicloud](https://github.com/gardener/gardener-extension-os-ubuntu-alicloud). Its implementation is using the [`oscommon`](https://github.com/gardener/gardener/blob/master/extensions/pkg/controller/operatingsystemconfig/oscommon/README.md) library for operating system configuration controllers.
 
 Please find more information regarding the extensibility concepts and a detailed proposal [here](https://github.com/gardener/gardener/blob/master/docs/proposals/01-extensibility.md).
 


### PR DESCRIPTION
Not sure if this was ever working before.