### PR TITLE
Fix gardenlinux team name in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # gardener-extension-os-gardenlinux maintainers
-* @gardener-extension-os-gardenlinux-maintainers @gardener/gardener-maintainers
+* @gardener/gardener-extension-os-gardenlinux-maintainers @gardener/gardener-maintainers


### PR DESCRIPTION
Fix gardenlinux team name in CODEOWNERS