### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 5
+  allow:
+  - dependency-name: "github.com/gardener/gardener"
+  labels:
+  - kind/enhancement

--- a/.github/workflows/vendor_gardener.yaml
+++ b/.github/workflows/vendor_gardener.yaml
@@ -1,0 +1,31 @@
+name: Vendor Gardener
+on:
+  push:
+    branches:
+    - dependabot/go_modules/github.com/gardener/**
+  pull_request:
+    branches:
+    - dependabot/go_modules/github.com/gardener/**
+permissions: write-all
+jobs:
+  run:
+    name: Run make revendor
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version-file: go.mod
+          
+    - name: Use gardener's replaced client-go version
+      run: go mod edit -replace 'k8s.io/client-go=k8s.io/client-go@'"$(go list -m -f '{{.Version}}' k8s.io/api)"
+      
+    - name: Make revendor
+      run: make revendor
+    - name: Commit changes
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add .
+        git commit -m "make revendor"
+        git push origin


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/os garden-linux

**What this PR does / why we need it**:
Configures dependabot and github actions to create automatic gardener/gardener dependency updates.
Linked to https://github.com/gardener/gardener/issues/6328

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6328

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The os-gardenlinux extension does now enable dependabot for automatic dependency update PRs for the `github.com/gardener/gardener` dependency.
```
