### PR TITLE
Adapt the "Vendor Gardener" github action to use the gardener-robot-ci-1 user

### DIFF
--- a/.github/workflows/vendor_gardener.yaml
+++ b/.github/workflows/vendor_gardener.yaml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
     - dependabot/go_modules/github.com/gardener/**
-  pull_request:
-    branches:
-    - dependabot/go_modules/github.com/gardener/**
 permissions: write-all
 jobs:
   run:
@@ -24,8 +21,8 @@ jobs:
       run: make revendor
     - name: Commit changes
       run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
+        git config user.name gardener-robot-ci-1
+        git config user.email gardener.ci.user1@gmail.com
         git add .
-        git commit -m "make revendor"
+        git commit -m "[dependabot skip] make revendor"
         git push origin


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
The currently used user does not sign the CLA. This adapt changes the user to `gardener-robot-ci-1`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
