### PR TITLE
vendor-gardener action: Do not fail when there is nothing to commit

### DIFF
--- a/.github/workflows/vendor_gardener.yaml
+++ b/.github/workflows/vendor_gardener.yaml
@@ -21,8 +21,15 @@ jobs:
       run: make revendor
     - name: Commit changes
       run: |
+        # Exit early if there is nothing to commit. This can happen if someone pushes to the dependabot's PR (for example has to adapt to a breaking change).
+        if [[ -z $(git status --porcelain) ]]; then
+          echo "Nothing to commit, working tree clean. Exiting..."
+          exit 0
+        fi
+        
         git config user.name gardener-robot-ci-1
         git config user.email gardener.ci.user@gmail.com
+
         git add .
         git commit -m "[dependabot skip] make revendor"
         git push origin


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/os garden-linux

**What this PR does / why we need it**:
Currently, if someone pushes to the dependabot's PR, then the vendor-gardener github action tries to run again and to commit again. However, its commit already exists, hence `make revendor` does not generate any change.
In such cases the github action fails with:
```
nothing to commit, working tree clean
Error: Process completed with exit code 1.
```

**Which issue(s) this PR fixes**:
See above

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
