### PR TITLE
Introduce the use of central manifest

### DIFF
--- a/.docforge/manifest.yaml
+++ b/.docforge/manifest.yaml
@@ -1,3 +1,0 @@
-structure:
-- name: _index.md
-  source: /README.md


### PR DESCRIPTION
**How to categorize this PR?**
/area documentation
/kind enhancement
/os garden-linux

**What this PR does / why we need it**:
Removes local manifest file and `check-docforge` that checks it's validity if present
Part of https://github.com/gardener/documentation/pull/430

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
