### PR TITLE
add override.conf containerd dropin to set LimitMEMLOCK and LimitNOFILE

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -134,10 +134,17 @@ Content-Type: text/x-shellscript
 
 func (a *actuator) handleReconcileOSC(_ *extensionsv1alpha1.OperatingSystemConfig) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
 
-	// TODO(MrBatschner): remove once https://github.com/gardener/gardener/issues/10809 in GNA has been resolved
 	extensionUnits := []extensionsv1alpha1.Unit{
 		{
 			Name: "containerd.service",
+			DropIns: []extensionsv1alpha1.DropIn{
+				{
+					Name: "override.conf",
+					Content: `[Service]
+LimitMEMLOCK=67108864
+LimitNOFILE=1048576`,
+				},
+			},
 		},
 	}
 

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -151,6 +151,14 @@ Content-Type: text/x-shellscript
 				Expect(units).To(ContainElement(
 					extensionsv1alpha1.Unit{
 						Name: "containerd.service",
+						DropIns: []extensionsv1alpha1.DropIn{
+							{
+								Name: "override.conf",
+								Content: `[Service]
+LimitMEMLOCK=67108864
+LimitNOFILE=1048576`,
+							},
+						},
 					},
 				))
 				Expect(files).To(BeEmpty())


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind bug
/os garden-linux

**What this PR does / why we need it**:

Gardener Node Agent deletes all service unit drop ins if none is known to him. Adding the drop-in file ensures the directory is not deleted. The `override.conf` is currently part of garden linux but might be removed in the future.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adds an override.conf containerd dropin file to set LimitMEMLOCK and LimitNOFILE
```
