### PR TITLE
Remove docker from the `provision` OperatingSystemConfig

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -89,7 +89,6 @@ nslookup $(hostname) || systemctl restart systemd-networkd
 
 systemctl daemon-reload
 systemctl enable containerd && systemctl restart containerd
-systemctl enable docker && systemctl restart docker
 `
 	for _, unit := range osc.Spec.Units {
 		script += fmt.Sprintf(`systemctl enable '%s' && systemctl restart --no-block '%s'

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -84,7 +84,6 @@ nslookup $(hostname) || systemctl restart systemd-networkd
 
 systemctl daemon-reload
 systemctl enable containerd && systemctl restart containerd
-systemctl enable docker && systemctl restart docker
 systemctl enable 'some-unit' && systemctl restart --no-block 'some-unit'
 `
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind cleanup
/os garden-linux

**What this PR does / why we need it**:
This PR removes executions of docker commands in the init OperatingSystemConfig.

From Gardener side, the `docker` binary is no longer used/required on a Shoot Node: https://github.com/gardener/gardener/issues/4673.
From gardeninux OS side, [gardenlinux@1443.1+](https://github.com/gardenlinux/gardenlinux/releases/tag/1443.1) no longer includes the `docker` binary unit in the OS.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The os-gardenlinux extension does no longer enable and restart the `docker` unit as part of the init OperatingSystemConfig. Gardener and Kubernetes does no longer support `docker` as CRI. Gardener does no longer rely on the `docker` binary to be present on the Nodes. [gardenlinux@1443.1+](https://github.com/gardenlinux/gardenlinux/releases/tag/1443.1) no longer includes the `docker` binary unit in the OS.
```

```breaking user
The os-gardenlinux extension does no longer enable and restart the `docker` unit as part of the init OperatingSystemConfig. If you, as end user, rely on the docker unit to be enabled by default on the Node, this is a breaking change for you. In such case, you would need to enable the docker unit on your own.
Pay attention that [gardenlinux@1443.1+](https://github.com/gardenlinux/gardenlinux/releases/tag/1443.1) no longer includes the `docker` binary unit in the OS.
```