### PR TITLE
Chore: remove docker references from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ status:
       namespace: default
   command: /usr/bin/env bash <path>
   units:
-  - docker-monitor.service
   - kubelet-monitor.service
   - kubelet.service
 ```

--- a/example/40-operatingsystemconfig-gardenlinux.yaml
+++ b/example/40-operatingsystemconfig-gardenlinux.yaml
@@ -7,33 +7,20 @@ metadata:
 spec:
   type: gardenlinux
   units:
-  - name: docker.service
+  - name: containerd.service
     dropIns:
-    - name: 10-docker-opts.conf
+    - name: preconfig-script.conf
       content: |
         [Service]
-        Environment="DOCKER_OPTS=--log-opt max-size=60m --log-opt max-file=3"
-  - name: docker-monitor.service
-    command: start
-    enable: true
-    content: |
-      [Unit]
-      Description=Docker-monitor daemon
-      After=kubelet.service
-      [Install]
-      WantedBy=multi-user.target
-      [Service]
-      Restart=always
-      EnvironmentFile=/etc/environment
-      ExecStart=/opt/bin/health-monitor docker
+        ExecStartPre="/var/lib/example/preconf-script.sh"
   files:
-  - path: /var/lib/example/file.txt
-    permissions: 0644
+  - path: /var/lib/example/preconf-script.sh
+    permissions: 0755
     encoding: b64
     content:
       secretRef:
-        name: example-file
-        dataKey: file.txt
+        name: containerd-preconf-script
+        dataKey: preconf-script.sh
   - path: /etc/sysctl.d/99-k8s-general.conf
     permissions: 0644
     content:

--- a/example/40-operatingsystemconfig-memoryonegardenlinux.yaml
+++ b/example/40-operatingsystemconfig-memoryonegardenlinux.yaml
@@ -7,33 +7,20 @@ metadata:
 spec:
   type: memoryone-gardenlinux
   units:
-  - name: docker.service
+  - name: containerd.service
     dropIns:
-    - name: 10-docker-opts.conf
+    - name: preconfig-script.conf
       content: |
         [Service]
-        Environment="DOCKER_OPTS=--log-opt max-size=60m --log-opt max-file=3"
-  - name: docker-monitor.service
-    command: start
-    enable: true
-    content: |
-      [Unit]
-      Description=Docker-monitor daemon
-      After=kubelet.service
-      [Install]
-      WantedBy=multi-user.target
-      [Service]
-      Restart=always
-      EnvironmentFile=/etc/environment
-      ExecStart=/opt/bin/health-monitor docker
+        ExecStartPre="/var/lib/example/preconf-script.sh"
   files:
-  - path: /var/lib/example/file.txt
-    permissions: 0644
+  - path: /var/lib/example/preconf-script.sh
+    permissions: 0755
     encoding: b64
     content:
       secretRef:
-        name: example-file
-        dataKey: file.txt
+        name: containerd-preconf-script
+        dataKey: preconf-script.sh
   - path: /etc/sysctl.d/99-k8s-general.conf
     permissions: 0644
     content:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind cleanup
/os garden-linux

**What this PR does / why we need it**:

The Garden Linux extension no longer supports anything related to Docker since PR #221 so we should also remove all references to Docker units from the example and README files.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
