### PR TITLE
Normalize OS version before passing to command

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	"github.com/go-logr/logr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -184,7 +185,7 @@ LimitNOFILE=1048576`,
 		inPlaceUpdates = &extensionsv1alpha1.InPlaceUpdatesStatus{
 			OSUpdate: &extensionsv1alpha1.OSUpdate{
 				Command: filePathOSUpdateScript,
-				Args:    []string{osc.Spec.InPlaceUpdates.OperatingSystemVersion},
+				Args:    []string{versionutils.Normalize(osc.Spec.InPlaceUpdates.OperatingSystemVersion)},
 			},
 		}
 	}

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -154,6 +154,24 @@ Content-Type: text/x-shellscript
 				Expect(userData).To(BeEmpty())
 			})
 
+			Context("In-Place Updates", func() {
+				It("should return InPlaceUpdatesStatus", func() {
+					osc.Spec.InPlaceUpdates = &extensionsv1alpha1.InPlaceUpdates{
+						OperatingSystemVersion: "1.0.0-inplace",
+					}
+
+					_, _, _, inplaceUpdateStatus, err := actuator.Reconcile(ctx, log, osc)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(inplaceUpdateStatus).To(Equal(&extensionsv1alpha1.InPlaceUpdatesStatus{
+						OSUpdate: &extensionsv1alpha1.OSUpdate{
+							Command: "/opt/gardener/bin/inplace-update.sh",
+							Args:    []string{"1.0.0"},
+						},
+					}))
+				})
+			})
+
 			It("should add one empty additional unit for containerd", func() {
 				_, units, files, _, err := actuator.Reconcile(ctx, log, osc)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/os garden-linux

**What this PR does / why we need it**:
gardenlinux version can contain suffixes like `1.0.0-inplace` which can cause issues while the `gardenlinux-update` tool tries to pull the image.
This PR fixes this issue by normalizing the version before passing it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing gardenlinux-update tool to fail with version suffixes is now fixed.
```
