### PR TITLE
Update CI build status badge (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Gardener Extension for Garden Linux OS](https://gardener.cloud)
 [![REUSE status](https://api.reuse.software/badge/github.com/gardener/gardener-extension-os-gardenlinux)](https://api.reuse.software/info/github.com/gardener/gardener-extension-os-gardenlinux)
-[![Build status](https://github.com/gardener/gardener-extension-os-gardenlinux/actions/workflows/non-release.yaml/badge.svg?branch=master)](https://github.com/gardener/gardener-extension-os-gardenlinux/actions/workflows/non-release.yaml)
+[![Build status](https://github.com/gardener/gardener-extension-os-gardenlinux/actions/workflows/dev_build/badge.svg?branch=master)](https://github.com/gardener/gardener-extension-os-gardenlinux/actions/workflows/dev_build)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gardener/gardener-extension-os-gardenlinux)](https://goreportcard.com/report/github.com/gardener/gardener-extension-os-gardenlinux)
 
 This controller operates on the [`OperatingSystemConfig`](https://github.com/gardener/gardener/blob/master/docs/proposals/01-extensibility.md#cloud-config-user-data-for-bootstrapping-machines) resource in the `extensions.gardener.cloud/v1alpha1` API group. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Gardener Extension for Garden Linux OS](https://gardener.cloud)
 [![REUSE status](https://api.reuse.software/badge/github.com/gardener/gardener-extension-os-gardenlinux)](https://api.reuse.software/info/github.com/gardener/gardener-extension-os-gardenlinux)
-[![Build status](https://github.com/gardener/gardener-extension-os-gardenlinux/actions/workflows/dev_build/badge.svg?branch=master)](https://github.com/gardener/gardener-extension-os-gardenlinux/actions/workflows/dev_build)
+[![Build status](https://github.com/gardener/gardener-extension-os-gardenlinux/actions/workflows/dev_build.yaml/badge.svg?branch=master)](https://github.com/gardener/gardener-extension-os-gardenlinux/actions/workflows/dev_build.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gardener/gardener-extension-os-gardenlinux)](https://goreportcard.com/report/github.com/gardener/gardener-extension-os-gardenlinux)
 
 This controller operates on the [`OperatingSystemConfig`](https://github.com/gardener/gardener/blob/master/docs/proposals/01-extensibility.md#cloud-config-user-data-for-bootstrapping-machines) resource in the `extensions.gardener.cloud/v1alpha1` API group. 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind cleanup
/os garden-linux

**What this PR does / why we need it**:

Updates the CI status badge to point to GitHub actions after GHA workflow name change.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
