### PR TITLE
ci: fix permission for pull_request_target in conjunction with truste…

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,6 +83,8 @@ jobs:
         with:
           go-version: '1.24'
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
+        with:
+          remove-trusted-label: false
       - name: run-verify
         run: |
           set -eu


### PR DESCRIPTION
**What this PR does / why we need it**:
If using pull_request_target in conjunction with trusted-label, trusted-checkout-action attempts to remove trusted-label. In order to do so, pull-requests: write-permission is needed.

Also added commit to not attempt removal of trusted labels in verify step. See [docs](https://github.com/gardener/cc-utils/blob/638a06aa7269ff36d8e616b300ef1f9a8a574d31/.github/actions/trusted-checkout/action.yaml#L41). Earlier run with `remove-trusted-label: true` is via prepare workflow ([see](https://github.com/gardener/cc-utils/blob/638a06aa7269ff36d8e616b300ef1f9a8a574d31/.github/workflows/prepare.yaml#L193)) in prepare step 

**Special notes for your reviewer**:
Issue resolved in other gardener repo here: https://github.com/gardener/dashboard/commit/1c8977dda50e5ef0334cb8412a9c9018da36f241

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
