### PR TITLE
ci(deps): group gardener Go module updates in Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,10 @@ updates:
   open-pull-requests-limit: 5
   allow:
   - dependency-name: "github.com/gardener/gardener"
+  groups:
+    gardener:
+      patterns:
+      - "github.com/gardener/gardener*"
   labels:
   - "kind/dependency-update"
 # Create PRs for golang version updates


### PR DESCRIPTION

/area dev-productivity
/kind enhancement
/os garden-linux

## Summary
- Add `groups` configuration to Dependabot so that `github.com/gardener/gardener` and `github.com/gardener/gardener/pkg/apis` are updated in a single PR instead of two separate ones.

## Test plan
- [ ] Verify next Dependabot run opens a single grouped PR for both gardener modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to improve organization of automated updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->