### PR TITLE
feat: add etc-setup hook script for wipe-based in-place OS upgrades

### DIFF
--- a/pkg/controller/operatingsystemconfig/actuator.go
+++ b/pkg/controller/operatingsystemconfig/actuator.go
@@ -5,10 +5,13 @@
 package operatingsystemconfig
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
+	"encoding/base64"
 	"fmt"
 	"path/filepath"
+	"text/template"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -41,7 +44,10 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, osc *extensions
 		return []byte(userData), nil, nil, nil, err
 
 	case extensionsv1alpha1.OperatingSystemConfigPurposeReconcile:
-		extensionUnits, extensionFiles, inPlaceUpdates := a.handleReconcileOSC(osc)
+		extensionUnits, extensionFiles, inPlaceUpdates, err := a.handleReconcileOSC(osc)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
 		return nil, extensionUnits, extensionFiles, inPlaceUpdates, nil
 
 	default:
@@ -139,16 +145,54 @@ Content-Type: text/x-shellscript
 	return out, nil
 }
 
-var scriptContentInPlaceUpdate []byte
+var (
+	scriptContentInPlaceUpdate []byte
+	etcSetupHookTpl            *template.Template
+)
 
 func init() {
 	var err error
 
 	scriptContentInPlaceUpdate, err = gardenlinux.Templates.ReadFile(filepath.Join("scripts", "inplace-update.sh"))
 	utilruntime.Must(err)
+
+	hookTplContent, err := gardenlinux.Templates.ReadFile(filepath.Join("scripts", "etc-setup-hook.tpl.sh"))
+	utilruntime.Must(err)
+	etcSetupHookTpl = template.Must(template.New("etc-setup-hook").Parse(string(hookTplContent)))
 }
 
-func (a *actuator) handleReconcileOSC(osc *extensionsv1alpha1.OperatingSystemConfig) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, *extensionsv1alpha1.InPlaceUpdatesStatus) {
+// unitForHook holds just the fields the hook template needs.
+type unitForHook struct {
+	Name       string
+	ContentB64 string // base64-encoded unit content; decoded by the hook script via `base64 -d`
+}
+
+// etcSetupHookData is the typed template data passed to etcSetupHookTpl.
+// Using a named struct (instead of map[string]any) makes key-name mismatches a
+// compile-time error rather than a silent empty-output bug.
+type etcSetupHookData struct {
+	Units []unitForHook
+}
+
+func generateEtcSetupHookScript(oscUnits []extensionsv1alpha1.Unit) ([]byte, error) {
+	var units []unitForHook
+	for _, u := range oscUnits {
+		if u.Content != nil && *u.Content != "" {
+			units = append(units, unitForHook{
+				Name:       u.Name,
+				ContentB64: base64.StdEncoding.EncodeToString([]byte(*u.Content)),
+			})
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := etcSetupHookTpl.Execute(&buf, etcSetupHookData{Units: units}); err != nil {
+		return nil, fmt.Errorf("failed rendering etc-setup hook script: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func (a *actuator) handleReconcileOSC(osc *extensionsv1alpha1.OperatingSystemConfig) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, *extensionsv1alpha1.InPlaceUpdatesStatus, error) {
 	var (
 		extensionUnits []extensionsv1alpha1.Unit
 		extensionFiles []extensionsv1alpha1.File
@@ -182,6 +226,21 @@ LimitNOFILE=1048576`,
 			Permissions: &gardenlinux.ScriptPermissions,
 		})
 
+		hookScript, err := generateEtcSetupHookScript(osc.Spec.Units)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		extensionFiles = append(extensionFiles, extensionsv1alpha1.File{
+			Path: gardenlinux.PathEtcSetupHook,
+			Content: extensionsv1alpha1.FileContent{
+				Inline: &extensionsv1alpha1.FileContentInline{
+					Data:     utils.EncodeBase64(hookScript),
+					Encoding: "b64",
+				},
+			},
+			Permissions: &gardenlinux.ScriptPermissions,
+		})
+
 		inPlaceUpdates = &extensionsv1alpha1.InPlaceUpdatesStatus{
 			OSUpdate: &extensionsv1alpha1.OSUpdate{
 				Command: filePathOSUpdateScript,
@@ -190,5 +249,5 @@ LimitNOFILE=1048576`,
 		}
 	}
 
-	return extensionUnits, extensionFiles, inPlaceUpdates
+	return extensionUnits, extensionFiles, inPlaceUpdates, nil
 }

--- a/pkg/controller/operatingsystemconfig/actuator_test.go
+++ b/pkg/controller/operatingsystemconfig/actuator_test.go
@@ -6,6 +6,8 @@ package operatingsystemconfig_test
 
 import (
 	"context"
+	"encoding/base64"
+	"strings"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -156,11 +158,18 @@ Content-Type: text/x-shellscript
 			})
 
 			Context("In-Place Updates", func() {
-				It("should return InPlaceUpdatesStatus", func() {
+				BeforeEach(func() {
 					osc.Spec.InPlaceUpdates = &extensionsv1alpha1.InPlaceUpdates{
 						OperatingSystemVersion: "1.0.0-inplace",
 					}
+					osc.Spec.Units = []extensionsv1alpha1.Unit{
+						{Name: "gardener-node-agent.service", Content: ptr.To("[Unit]\nDescription=GNA")},
+						{Name: "kubelet.service", Content: ptr.To("[Unit]\nDescription=kubelet")},
+						{Name: "no-content.service"}, // units without content must be skipped
+					}
+				})
 
+				It("should return InPlaceUpdatesStatus with the OS update command", func() {
 					_, _, _, inplaceUpdateStatus, err := actuator.Reconcile(ctx, log, osc)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -170,6 +179,74 @@ Content-Type: text/x-shellscript
 							Args:    []string{"1.0.0"},
 						},
 					}))
+				})
+
+				It("should deliver the inplace-update.sh script and the etc-setup hook file", func() {
+					_, _, files, _, err := actuator.Reconcile(ctx, log, osc)
+					Expect(err).NotTo(HaveOccurred())
+
+					paths := make([]string, 0, len(files))
+					for _, f := range files {
+						paths = append(paths, f.Path)
+					}
+					Expect(paths).To(ContainElements(
+						"/opt/gardener/bin/inplace-update.sh",
+						gardenlinux.PathEtcSetupHook,
+					))
+				})
+
+				It("should embed all unit contents with content in the hook script", func() {
+					_, _, files, _, err := actuator.Reconcile(ctx, log, osc)
+					Expect(err).NotTo(HaveOccurred())
+
+					var hookFile *extensionsv1alpha1.File
+					for i := range files {
+						if files[i].Path == gardenlinux.PathEtcSetupHook {
+							hookFile = &files[i]
+							break
+						}
+					}
+					Expect(hookFile).NotTo(BeNil())
+					Expect(hookFile.Content.Inline).NotTo(BeNil())
+					Expect(hookFile.Content.Inline.Encoding).To(Equal("b64"))
+
+					decoded, err := base64.StdEncoding.DecodeString(hookFile.Content.Inline.Data)
+					Expect(err).NotTo(HaveOccurred())
+
+					script := string(decoded)
+					Expect(script).To(ContainSubstring("#!/usr/bin/env bash"))
+					// Unit names appear verbatim in the script (as install targets and restart targets)
+					Expect(script).To(ContainSubstring("gardener-node-agent.service"))
+					Expect(script).To(ContainSubstring("kubelet.service"))
+					// Unit content is base64-encoded in the script to prevent heredoc injection
+					Expect(script).To(ContainSubstring(base64.StdEncoding.EncodeToString([]byte("[Unit]\nDescription=GNA"))))
+					Expect(script).To(ContainSubstring(base64.StdEncoding.EncodeToString([]byte("[Unit]\nDescription=kubelet"))))
+					// unit without content must not appear
+					Expect(strings.Count(script, "no-content.service")).To(Equal(0))
+					// containerd setup must be present
+					Expect(script).To(ContainSubstring("containerd config default"))
+					Expect(script).To(ContainSubstring("11-exec_config.conf"))
+					Expect(script).To(ContainSubstring("systemctl daemon-reload"))
+					// containerd drop-in with resource limits must be written by the hook
+					Expect(script).To(ContainSubstring("override.conf"))
+					Expect(script).To(ContainSubstring("LimitMEMLOCK=67108864"))
+					Expect(script).To(ContainSubstring("LimitNOFILE=1048576"))
+					// last-applied-osc.yaml must be removed so GNA re-applies all files after the wipe
+					Expect(script).To(ContainSubstring("rm -f /var/lib/gardener-node-agent/last-applied-osc.yaml"))
+				})
+
+				It("should set 0755 permissions on the hook file", func() {
+					_, _, files, _, err := actuator.Reconcile(ctx, log, osc)
+					Expect(err).NotTo(HaveOccurred())
+
+					for _, f := range files {
+						if f.Path == gardenlinux.PathEtcSetupHook {
+							Expect(f.Permissions).NotTo(BeNil())
+							Expect(*f.Permissions).To(Equal(uint32(0755)))
+							return
+						}
+					}
+					Fail("hook file not found in extension files")
 				})
 			})
 

--- a/pkg/gardenlinux/constants.go
+++ b/pkg/gardenlinux/constants.go
@@ -19,6 +19,12 @@ const (
 	// ScriptLocation is the location that Gardener configuration scripts end up on Garden Linux
 	ScriptLocation = "/opt/gardener/bin"
 
+	// PathEtcSetupHook is the path of the etc-setup hook script on the worker node.
+	// GardenLinux executes all executables in this directory via run-parts after the /etc overlay is
+	// wiped during a major OS version upgrade (wipe-based in-place update). The filename has no
+	// extension so that Debian run-parts (default regex ^[a-zA-Z0-9_-]+$) does not skip it.
+	PathEtcSetupHook = "/var/lib/gardenlinux/etc-setup-hooks/00-gardener"
+
 	// OSTypeGardenLinux is a constant for the Garden Linux extension OS type.
 	OSTypeGardenLinux = "gardenlinux"
 

--- a/pkg/gardenlinux/scripts/etc-setup-hook.tpl.sh
+++ b/pkg/gardenlinux/scripts/etc-setup-hook.tpl.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This script is installed at /var/lib/gardenlinux/etc-setup-hooks/ and is executed
+# by GardenLinux via run-parts after the /etc overlay is wiped during a wipe-based
+# in-place OS version upgrade. It restores all /etc state that Gardener manages so
+# that the node rejoins the cluster without a full re-bootstrap.
+#
+# All credentials and data in /var/lib/ (GNA kubeconfig, kubelet certs, containerd
+# image store) survive the wipe unchanged, so no certificate re-issuance is needed.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "> Restoring /etc state after overlay wipe"
+
+# --- containerd ---
+if [ ! -s /etc/containerd/config.toml ]; then
+  mkdir -p /etc/containerd/
+  containerd config default > /etc/containerd/config.toml
+  chmod 0644 /etc/containerd/config.toml
+fi
+
+mkdir -p /etc/systemd/system/containerd.service.d
+printf '%s' '[Service]
+ExecStart=
+ExecStart=/usr/bin/containerd --config=/etc/containerd/config.toml' \
+  > /etc/systemd/system/containerd.service.d/11-exec_config.conf
+chmod 0644 /etc/systemd/system/containerd.service.d/11-exec_config.conf
+
+printf '%s' '[Service]
+LimitMEMLOCK=67108864
+LimitNOFILE=1048576' \
+  > /etc/systemd/system/containerd.service.d/override.conf
+chmod 0644 /etc/systemd/system/containerd.service.d/override.conf
+
+# --- systemd units ---
+# Unit content is base64-encoded at generation time to avoid any shell injection
+# via heredoc delimiters or metacharacters in the content.
+{{ range .Units -}}
+mkdir -p /etc/systemd/system
+printf '%s' '{{ .ContentB64 }}' | base64 -d > /etc/systemd/system/'{{ .Name }}'
+{{ end }}
+systemctl daemon-reload
+
+# enable+start containerd first so other units that depend on it can start
+systemctl enable containerd.service
+systemctl restart containerd.service
+
+# enable all units from the OSC; start only non-template units
+{{ range .Units -}}
+systemctl enable '{{ .Name }}'
+systemctl restart --no-block '{{ .Name }}' || true
+{{ end }}
+echo "> Done restoring /etc state"
+
+# Remove the last-applied OSC snapshot so GNA re-applies all files and units
+# on the next reconcile. Without this, GNA's diff against the old snapshot would
+# only re-write files that changed between OS versions — leaving unchanged files
+# (journald.conf, CA bundle in /etc/pki, etc.) missing from the wiped /etc.
+rm -f /var/lib/gardener-node-agent/last-applied-osc.yaml


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area os
/kind enhancement
/os garden-linux

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/14457

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
